### PR TITLE
Fixes occasional result of -0

### DIFF
--- a/src/Core/Evaluation.vala
+++ b/src/Core/Evaluation.vala
@@ -263,6 +263,8 @@ namespace PantheonCalculator.Core {
             try {
                 Operator op = get_operator (t_op);
                 var d = (double)(op.eval (double.parse (t2.content), double.parse (t1.content)));
+                if (fabs (d) - 0.0 < double.EPSILON ) {
+		        d = 0; }
                 return new Token (d.to_string (), TokenType.NUMBER);
             } catch (SHUNTING_ERROR e) { throw new EVAL_ERROR.NO_OPERATOR ("The given token was no operator."); }
         }


### PR DESCRIPTION
Made changes to the compute_tokens function that checks for negative 0s by comparing result minus 0 to epsilon and sets them to 0 if found.

Addresses issue # 1 clicked around, got result -0. -0 results occurred after performing a calculation that resulted in a negative number and then multiplying the answer by 0. i.e. (5-6 = -1 then -1*0 = -0).